### PR TITLE
Fix frontend repo selection tab display

### DIFF
--- a/www/src/components/file/FileTreeBrowser.tsx
+++ b/www/src/components/file/FileTreeBrowser.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useAtom } from 'jotai';
-import { selectedRepositoryFromListAtom, selectedFilesAtom } from '@/store/atoms';
+import { selectedRepositoryAtom, selectedFilesAtom } from '@/store/atoms';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '@/lib/api-client';
 import { Button } from '@/components/ui/button';
@@ -22,7 +22,7 @@ interface TreeNode extends FileInfo {
 }
 
 export default function FileTreeBrowser() {
-    const [currentRepository] = useAtom(selectedRepositoryFromListAtom);
+    const [currentRepository] = useAtom(selectedRepositoryAtom);
     const [selectedFiles, setSelectedFiles] = useAtom(selectedFilesAtom);
     const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
 

--- a/www/src/components/file/FileViewer.tsx
+++ b/www/src/components/file/FileViewer.tsx
@@ -1,5 +1,5 @@
 import { useAtom } from 'jotai';
-import { selectedRepositoryFromListAtom, selectedFilesAtom } from '@/store/atoms';
+import { selectedRepositoryAtom, selectedFilesAtom } from '@/store/atoms';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '@/lib/api-client';
 import { Button } from '@/components/ui/button';
@@ -70,7 +70,7 @@ const isImageFile = (fileName: string): boolean => {
 
 
 export default function FileViewer() {
-    const [currentRepository] = useAtom(selectedRepositoryFromListAtom);
+    const [currentRepository] = useAtom(selectedRepositoryAtom);
     const [selectedFiles] = useAtom(selectedFilesAtom);
 
     const selectedFile = selectedFiles[0]; // For now, just show the first selected file

--- a/www/src/components/layout/Header.tsx
+++ b/www/src/components/layout/Header.tsx
@@ -1,11 +1,11 @@
 import { useAtom } from 'jotai';
-import { sidebarOpenAtom, selectedRepositoryFromListAtom, activeViewAtom } from '@/store/atoms';
+import { sidebarOpenAtom, selectedRepositoryAtom, activeViewAtom } from '@/store/atoms';
 import { Button } from '@/components/ui/button';
 import { Menu, GitBranch, FolderOpen, History, Settings, GitMerge, RefreshCw, GitCompare } from 'lucide-react';
 
 export default function Header() {
     const [sidebarOpen, setSidebarOpen] = useAtom(sidebarOpenAtom);
-    const [currentRepository] = useAtom(selectedRepositoryFromListAtom);
+    const [currentRepository] = useAtom(selectedRepositoryAtom);
     const [activeView, setActiveView] = useAtom(activeViewAtom);
 
     return (

--- a/www/src/components/layout/StatusBar.tsx
+++ b/www/src/components/layout/StatusBar.tsx
@@ -1,10 +1,10 @@
 import { useAtom } from 'jotai';
-import { selectedRepositoryFromListAtom, statusMessageAtom, progressAtom } from '@/store/atoms';
+import { selectedRepositoryAtom, statusMessageAtom, progressAtom } from '@/store/atoms';
 import { useRepositoryStatus } from '@/store/queries';
 import { GitBranch, Circle, AlertCircle, CheckCircle2 } from 'lucide-react';
 
 export default function StatusBar() {
-    const [currentRepository] = useAtom(selectedRepositoryFromListAtom);
+    const [currentRepository] = useAtom(selectedRepositoryAtom);
     const [statusMessage] = useAtom(statusMessageAtom);
     const [progress] = useAtom(progressAtom);
     

--- a/www/src/components/repository/BranchList.tsx
+++ b/www/src/components/repository/BranchList.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useAtom } from 'jotai';
-import { selectedRepositoryFromListAtom } from '@/store/atoms';
+import { selectedRepositoryAtom } from '@/store/atoms';
 import { useBranches, useSwitchBranch, useDeleteBranch } from '@/store/queries';
 import { format } from 'date-fns';
 import { GitBranch, GitMerge, Plus, Check, Hash, User, Calendar, Loader2, Trash2 } from 'lucide-react';
@@ -17,12 +17,18 @@ import {
 import CreateBranchDialog from './CreateBranchDialog';
 
 export default function BranchList() {
-    const [currentRepository] = useAtom(selectedRepositoryFromListAtom);
+    const [currentRepository] = useAtom(selectedRepositoryAtom);
     const { data: branches, isLoading, error } = useBranches(currentRepository?.id);
     const [showCreateDialog, setShowCreateDialog] = useState(false);
     const [deleteBranchName, setDeleteBranchName] = useState<string | null>(null);
     const switchBranchMutation = useSwitchBranch();
     const deleteBranchMutation = useDeleteBranch();
+
+    // Debug logging
+    console.log('BranchList - currentRepository:', currentRepository);
+    console.log('BranchList - branches:', branches);
+    console.log('BranchList - isLoading:', isLoading);
+    console.log('BranchList - error:', error);
 
     if (isLoading) {
         return (

--- a/www/src/components/repository/CommitDetailsDialog.tsx
+++ b/www/src/components/repository/CommitDetailsDialog.tsx
@@ -1,5 +1,5 @@
 import { useAtom } from 'jotai';
-import { selectedRepositoryFromListAtom } from '@/store/atoms';
+import { selectedRepositoryAtom } from '@/store/atoms';
 import { useCommitDetails } from '@/store/queries';
 import { format } from 'date-fns';
 import { GitCommit, User, Calendar, Hash, Plus, Minus, FileText, X } from 'lucide-react';
@@ -14,7 +14,7 @@ interface CommitDetailsDialogProps {
 }
 
 export default function CommitDetailsDialog({ commitHash, isOpen, onClose }: CommitDetailsDialogProps) {
-    const [currentRepository] = useAtom(selectedRepositoryFromListAtom);
+    const [currentRepository] = useAtom(selectedRepositoryAtom);
     const { data: commitDetails, isLoading, error } = useCommitDetails(currentRepository?.id, commitHash || undefined);
 
     const getChangeTypeColor = (changeType: string) => {

--- a/www/src/components/repository/CommitDialog.tsx
+++ b/www/src/components/repository/CommitDialog.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useAtom } from 'jotai';
-import { selectedRepositoryFromListAtom } from '@/store/atoms';
+import { selectedRepositoryAtom } from '@/store/atoms';
 import { useRepositoryStatus } from '@/store/queries';
 import {
     Dialog,
@@ -22,7 +22,7 @@ interface CommitDialogProps {
 }
 
 export default function CommitDialog({ open, onOpenChange }: CommitDialogProps) {
-    const [currentRepository] = useAtom(selectedRepositoryFromListAtom);
+    const [currentRepository] = useAtom(selectedRepositoryAtom);
     const { data: repoStatus } = useRepositoryStatus(currentRepository?.id);
     const [commitMessage, setCommitMessage] = useState('');
     const [authorName, setAuthorName] = useState('');

--- a/www/src/components/repository/CommitHistory.tsx
+++ b/www/src/components/repository/CommitHistory.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useAtom } from 'jotai';
-import { selectedRepositoryFromListAtom } from '@/store/atoms';
+import { selectedRepositoryAtom } from '@/store/atoms';
 import { useCommitHistory } from '@/store/queries';
 import { format } from 'date-fns';
 import { GitCommit, User, Calendar, Hash } from 'lucide-react';
@@ -8,9 +8,15 @@ import { Button } from '@/components/ui/button';
 import CommitDetailsDialog from './CommitDetailsDialog';
 
 export default function CommitHistory() {
-    const [currentRepository] = useAtom(selectedRepositoryFromListAtom);
+    const [currentRepository] = useAtom(selectedRepositoryAtom);
     const { data: commits, isLoading, error } = useCommitHistory(currentRepository?.id);
     const [selectedCommitHash, setSelectedCommitHash] = useState<string | null>(null);
+
+    // Debug logging
+    console.log('CommitHistory - currentRepository:', currentRepository);
+    console.log('CommitHistory - commits:', commits);
+    console.log('CommitHistory - isLoading:', isLoading);
+    console.log('CommitHistory - error:', error);
 
     if (isLoading) {
         return (

--- a/www/src/components/repository/CreateBranchDialog.tsx
+++ b/www/src/components/repository/CreateBranchDialog.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useAtom } from 'jotai';
-import { selectedRepositoryFromListAtom } from '@/store/atoms';
+import { selectedRepositoryAtom } from '@/store/atoms';
 import { useCreateBranch } from '@/store/queries';
 import {
     Dialog,
@@ -20,7 +20,7 @@ interface CreateBranchDialogProps {
 }
 
 export default function CreateBranchDialog({ open, onOpenChange }: CreateBranchDialogProps) {
-    const [currentRepository] = useAtom(selectedRepositoryFromListAtom);
+    const [currentRepository] = useAtom(selectedRepositoryAtom);
     const [branchName, setBranchName] = useState('');
     const createBranchMutation = useCreateBranch();
 

--- a/www/src/components/repository/RepositoryList.tsx
+++ b/www/src/components/repository/RepositoryList.tsx
@@ -30,6 +30,7 @@ export default function RepositoryList() {
   }
 
   const handleRepositorySelect = (repo: Repository) => {
+    console.log('RepositoryList - selecting repository:', repo);
     setSelectedRepository(repo);
     setSelectedRepositoryId(repo.id);
   };

--- a/www/src/components/repository/RepositoryPanel.tsx
+++ b/www/src/components/repository/RepositoryPanel.tsx
@@ -1,5 +1,5 @@
 import { useAtom } from 'jotai';
-import { activeViewAtom, selectedRepositoryFromListAtom } from '@/store/atoms';
+import { activeViewAtom, selectedRepositoryAtom } from '@/store/atoms';
 import FileTreeBrowser from '../file/FileTreeBrowser';
 import FileViewer from '../file/FileViewer';
 import CommitHistory from './CommitHistory';
@@ -8,7 +8,11 @@ import WorkingDirectoryChanges from './WorkingDirectoryChanges';
 
 export default function RepositoryPanel() {
     const [activeView] = useAtom(activeViewAtom);
-    const [currentRepository] = useAtom(selectedRepositoryFromListAtom);
+    const [currentRepository] = useAtom(selectedRepositoryAtom);
+
+    // Debug logging
+    console.log('RepositoryPanel - currentRepository:', currentRepository);
+    console.log('RepositoryPanel - activeView:', activeView);
 
     if (!currentRepository) {
         return (

--- a/www/src/components/repository/WorkingDirectoryChanges.tsx
+++ b/www/src/components/repository/WorkingDirectoryChanges.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useAtom } from 'jotai';
-import { selectedRepositoryFromListAtom } from '@/store/atoms';
+import { selectedRepositoryAtom } from '@/store/atoms';
 import { useRepositoryStatus, useStageFile, useUnstageFile } from '@/store/queries';
 import type { FileChange } from '@/types/api';
 import { 
@@ -154,11 +154,17 @@ function UntrackedFileItem({ fileName, onStage }: UntrackedFileItemProps) {
 }
 
 export default function WorkingDirectoryChanges() {
-    const [currentRepository] = useAtom(selectedRepositoryFromListAtom);
+    const [currentRepository] = useAtom(selectedRepositoryAtom);
     const { data: repoStatus, isLoading, error } = useRepositoryStatus(currentRepository?.id);
     const stageFileMutation = useStageFile();
     const unstageFileMutation = useUnstageFile();
     const [showCommitDialog, setShowCommitDialog] = useState(false);
+
+    // Debug logging
+    console.log('WorkingDirectoryChanges - currentRepository:', currentRepository);
+    console.log('WorkingDirectoryChanges - repoStatus:', repoStatus);
+    console.log('WorkingDirectoryChanges - isLoading:', isLoading);
+    console.log('WorkingDirectoryChanges - error:', error);
 
     const handleStageFile = (filePath: string) => {
         if (!currentRepository) return;

--- a/www/src/lib/api-client.ts
+++ b/www/src/lib/api-client.ts
@@ -11,11 +11,12 @@ import type {
     DirectoryEntry,
 } from '../types/api';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE;
+const API_BASE_URL = import.meta.env.VITE_API_BASE || 'http://localhost:8080';
 
 class ApiClient {
     private async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
         const url = `${API_BASE_URL}${endpoint}`;
+        console.log('API Client - Making request to:', url);
 
         const config: RequestInit = {
             headers: {
@@ -27,9 +28,11 @@ class ApiClient {
 
         try {
             const response = await fetch(url, config);
+            console.log('API Client - Response status:', response.status);
 
             if (!response.ok) {
                 const errorText = await response.text();
+                console.error('API Client - Error response:', errorText);
                 throw new ApiError({
                     message: errorText || `HTTP ${response.status}: ${response.statusText}`,
                     status: response.status,
@@ -40,8 +43,11 @@ class ApiClient {
                 return {} as T;
             }
 
-            return await response.json();
+            const data = await response.json();
+            console.log('API Client - Response data:', data);
+            return data;
         } catch (error) {
+            console.error('API Client - Request failed:', error);
             if (error instanceof ApiError) {
                 throw error;
             }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes frontend tabs not displaying content by unifying repository selection atom usage.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The issue stemmed from a dual repository selection system where tab components relied on `selectedRepositoryFromListAtom`, which was never populated, while the `RepositoryList` correctly used `selectedRepositoryAtom`. This PR updates all relevant components to consistently use `selectedRepositoryAtom`, ensuring proper data fetching for Status, Commit, and Branch tabs. Debugging logs and a default API base URL were also added for improved development experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-653834ce-72df-4056-83e4-7810d9ebcfe6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-653834ce-72df-4056-83e4-7810d9ebcfe6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>