### PR TITLE
test: add router list repositories test

### DIFF
--- a/server/internal/api/routes_test.go
+++ b/server/internal/api/routes_test.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "gitweb/server/internal/models"
+)
+
+func TestNewRouterListRepositories(t *testing.T) {
+    tempDir := t.TempDir()
+    r := NewRouter(tempDir)
+
+    req := httptest.NewRequest(http.MethodGet, "/api/repos", nil)
+    rr := httptest.NewRecorder()
+    r.ServeHTTP(rr, req)
+
+    if rr.Code != http.StatusOK {
+        t.Fatalf("expected status %d, got %d", http.StatusOK, rr.Code)
+    }
+
+    var repos []models.Repository
+    if err := json.Unmarshal(rr.Body.Bytes(), &repos); err != nil {
+        t.Fatalf("failed to decode response: %v", err)
+    }
+
+    if len(repos) != 0 {
+        t.Fatalf("expected empty repository list, got %d", len(repos))
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit test ensuring router lists repositories endpoint returns an empty list

## Testing
- `go test ./internal/api -run TestNewRouterListRepositories -v`
- `go test ./...` *(fails: existing tests in internal/api/handlers and internal/git)*

------
https://chatgpt.com/codex/tasks/task_e_689f30c798b4832f8143e8192981da5c