### PR TITLE
feat: add syntax highlighting to commit details

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -17,6 +17,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "highlight.js": "^11.11.1",
         "jotai": "^2.12.5",
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
@@ -3862,6 +3863,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/html-escaper": {

--- a/www/package.json
+++ b/www/package.json
@@ -20,6 +20,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "highlight.js": "^11.11.1",
     "jotai": "^2.12.5",
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",

--- a/www/src/components/repository/CommitDetailsDialog.tsx
+++ b/www/src/components/repository/CommitDetailsDialog.tsx
@@ -6,6 +6,11 @@ import { GitCommit, User, Calendar, Hash, Plus, Minus, FileText, X } from 'lucid
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
+import hljs from 'highlight.js/lib/core';
+import diff from 'highlight.js/lib/languages/diff';
+import 'highlight.js/styles/github.css';
+
+hljs.registerLanguage('diff', diff);
 
 interface CommitDetailsDialogProps {
     commitHash: string | null;
@@ -169,9 +174,12 @@ export default function CommitDetailsDialog({ commitHash, isOpen, onClose }: Com
                                         
                                         {change.patch && (
                                             <div className="p-4">
-                                                <pre className="text-xs bg-muted/50 p-3 rounded border overflow-x-auto whitespace-pre-wrap font-mono">
-                                                    {change.patch}
-                                                </pre>
+                                                <pre
+                                                    className="hljs text-xs bg-muted/50 p-3 rounded border overflow-x-auto whitespace-pre-wrap font-mono"
+                                                    dangerouslySetInnerHTML={{
+                                                        __html: hljs.highlight(change.patch, { language: 'diff' }).value,
+                                                    }}
+                                                />
                                             </div>
                                         )}
                                     </div>


### PR DESCRIPTION
## Summary
- add highlight.js dependency
- highlight commit patches in CommitDetailsDialog

## Testing
- `npm test`
- `npm run lint` (fails: existing linter errors)
- `go test ./...` (fails: existing test failures)


------
https://chatgpt.com/codex/tasks/task_e_68a0d0372068832fa6c4e39834922f95