### PR TITLE
feat: add syntax highlighting to commit details

### DIFF
--- a/www/src/components/repository/CommitDetailsDialog.tsx
+++ b/www/src/components/repository/CommitDetailsDialog.tsx
@@ -8,9 +8,47 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Badge } from '@/components/ui/badge';
 import hljs from 'highlight.js/lib/core';
 import diff from 'highlight.js/lib/languages/diff';
+import javascript from 'highlight.js/lib/languages/javascript';
+import typescript from 'highlight.js/lib/languages/typescript';
+import python from 'highlight.js/lib/languages/python';
+import go from 'highlight.js/lib/languages/go';
+import java from 'highlight.js/lib/languages/java';
+import json from 'highlight.js/lib/languages/json';
+import bash from 'highlight.js/lib/languages/bash';
+import xml from 'highlight.js/lib/languages/xml';
+import css from 'highlight.js/lib/languages/css';
+import markdown from 'highlight.js/lib/languages/markdown';
+import c from 'highlight.js/lib/languages/c';
+import cpp from 'highlight.js/lib/languages/cpp';
+import csharp from 'highlight.js/lib/languages/csharp';
+import php from 'highlight.js/lib/languages/php';
+import ruby from 'highlight.js/lib/languages/ruby';
+import rust from 'highlight.js/lib/languages/rust';
+import yaml from 'highlight.js/lib/languages/yaml';
+import sql from 'highlight.js/lib/languages/sql';
+import toml from 'highlight.js/lib/languages/toml';
 import 'highlight.js/styles/github.css';
 
 hljs.registerLanguage('diff', diff);
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('typescript', typescript);
+hljs.registerLanguage('python', python);
+hljs.registerLanguage('go', go);
+hljs.registerLanguage('java', java);
+hljs.registerLanguage('json', json);
+hljs.registerLanguage('bash', bash);
+hljs.registerLanguage('xml', xml);
+hljs.registerLanguage('css', css);
+hljs.registerLanguage('markdown', markdown);
+hljs.registerLanguage('c', c);
+hljs.registerLanguage('cpp', cpp);
+hljs.registerLanguage('csharp', csharp);
+hljs.registerLanguage('php', php);
+hljs.registerLanguage('ruby', ruby);
+hljs.registerLanguage('rust', rust);
+hljs.registerLanguage('yaml', yaml);
+hljs.registerLanguage('sql', sql);
+hljs.registerLanguage('toml', toml);
 
 interface CommitDetailsDialogProps {
     commitHash: string | null;
@@ -46,6 +84,62 @@ export default function CommitDetailsDialog({ commitHash, isOpen, onClose }: Com
             default:
                 return <FileText className="h-3 w-3" />;
         }
+    };
+
+    const extensionToLanguage: Record<string, string> = {
+        js: 'javascript',
+        jsx: 'javascript',
+        ts: 'typescript',
+        tsx: 'typescript',
+        py: 'python',
+        go: 'go',
+        java: 'java',
+        rb: 'ruby',
+        php: 'php',
+        rs: 'rust',
+        c: 'c',
+        h: 'c',
+        cpp: 'cpp',
+        cxx: 'cpp',
+        hpp: 'cpp',
+        cc: 'cpp',
+        cs: 'csharp',
+        sh: 'bash',
+        bash: 'bash',
+        zsh: 'bash',
+        json: 'json',
+        yml: 'yaml',
+        yaml: 'yaml',
+        toml: 'toml',
+        md: 'markdown',
+        markdown: 'markdown',
+        html: 'xml',
+        xml: 'xml',
+        css: 'css',
+        sql: 'sql',
+    };
+
+    const getLanguageFromPath = (path: string): string | undefined => {
+        const ext = path.split('.').pop()?.toLowerCase();
+        return ext ? extensionToLanguage[ext] : undefined;
+    };
+
+    const renderPatch = (patch: string, language?: string) => {
+        return patch
+            .split('\n')
+            .map((line) => {
+                const sign = line[0];
+                const content = line.slice(1);
+                let highlighted = '';
+                if (language && hljs.getLanguage(language)) {
+                    highlighted = hljs.highlight(content, { language, ignoreIllegals: true }).value;
+                } else {
+                    highlighted = hljs.highlightAuto(content).value;
+                }
+                const lineClass = sign === '+' ? 'hljs-addition' : 'hljs-deletion';
+                return `<span class="${lineClass}">${sign}${highlighted}</span>`;
+            })
+            .join('\n');
     };
 
     return (
@@ -177,7 +271,7 @@ export default function CommitDetailsDialog({ commitHash, isOpen, onClose }: Com
                                                 <pre
                                                     className="hljs text-xs bg-muted/50 p-3 rounded border overflow-x-auto whitespace-pre-wrap font-mono"
                                                     dangerouslySetInnerHTML={{
-                                                        __html: hljs.highlight(change.patch, { language: 'diff' }).value,
+                                                        __html: renderPatch(change.patch, getLanguageFromPath(change.path)),
                                                     }}
                                                 />
                                             </div>


### PR DESCRIPTION
## Summary
- highlight commit diff code according to file type
- register common languages in CommitDetailsDialog
- render diff lines with syntax-aware highlighting

## Testing
- `npm test`
- `npm run lint` *(fails: Fast refresh only works... etc.)*
- `go test ./...` *(fails: Expected status 200, got 500)*


------
https://chatgpt.com/codex/tasks/task_e_68a0d6f3060c832fa9673b4f94ce06a4