### PR TITLE
feat: add line numbers to commit diff view

### DIFF
--- a/www/src/components/repository/CommitDetailsDialog.tsx
+++ b/www/src/components/repository/CommitDetailsDialog.tsx
@@ -125,6 +125,7 @@ export default function CommitDetailsDialog({ commitHash, isOpen, onClose }: Com
     };
 
     const renderPatch = (patch: string, language?: string) => {
+        let lineNumber = 1;
         return patch
             .split('\n')
             .map((line) => {
@@ -137,7 +138,9 @@ export default function CommitDetailsDialog({ commitHash, isOpen, onClose }: Com
                     highlighted = hljs.highlightAuto(content).value;
                 }
                 const lineClass = sign === '+' ? 'hljs-addition' : 'hljs-deletion';
-                return `<span class="${lineClass}">${sign}${highlighted}</span>`;
+                const rendered = `<span class="diff-line-number">${lineNumber}</span><span class="${lineClass}">${sign}${highlighted}</span>`;
+                lineNumber++;
+                return rendered;
             })
             .join('\n');
     };

--- a/www/src/index.css
+++ b/www/src/index.css
@@ -41,6 +41,12 @@
     --color-sidebar-ring: var(--sidebar-ring);
 }
 
+@layer components {
+    .diff-line-number {
+        @apply text-muted-foreground select-none inline-block w-10 text-right mr-2;
+    }
+}
+
 :root {
     --radius: 0.625rem;
     --background: oklch(1 0 0);


### PR DESCRIPTION
## Summary
- show line numbers for each line in commit diff view
- style diff line numbers

## Testing
- `npm test`
- `go test ./...` *(fails: repository_test.go expected status 200)*
- `npm run lint` *(fails: diff errors in ui and store components)*

------
https://chatgpt.com/codex/tasks/task_e_68a0db2c2e80832fa65ff1806d90293a