### PR TITLE
feat: add syntax highlighting for file view

### DIFF
--- a/www/src/components/file/FileViewer.tsx
+++ b/www/src/components/file/FileViewer.tsx
@@ -3,6 +3,7 @@ import { selectedRepositoryAtom, selectedFilesAtom } from '@/store/atoms';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '@/lib/api-client';
 import { Button } from '@/components/ui/button';
+import { hljs, getLanguageFromPath } from '@/lib/highlight';
 import { 
     File, 
     Loader2, 
@@ -160,11 +161,19 @@ export default function FileViewer() {
             );
         }
 
+        const language = getLanguageFromPath(fileName);
+        const highlighted = fileContent
+            ? language && hljs.getLanguage(language)
+                ? hljs.highlight(fileContent, { language, ignoreIllegals: true }).value
+                : hljs.highlightAuto(fileContent).value
+            : '';
+
         return (
             <div className="p-3">
-                <pre className="whitespace-pre-wrap text-sm font-mono bg-muted/30 p-3 rounded overflow-auto">
-                    {fileContent}
-                </pre>
+                <pre
+                    className="hljs whitespace-pre-wrap text-sm font-mono bg-muted/30 p-3 rounded overflow-auto"
+                    dangerouslySetInnerHTML={{ __html: highlighted }}
+                />
             </div>
         );
     };

--- a/www/src/components/repository/CommitDetailsDialog.tsx
+++ b/www/src/components/repository/CommitDetailsDialog.tsx
@@ -20,47 +20,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
-import hljs from "highlight.js/lib/core";
-import diff from "highlight.js/lib/languages/diff";
-import javascript from "highlight.js/lib/languages/javascript";
-import typescript from "highlight.js/lib/languages/typescript";
-import python from "highlight.js/lib/languages/python";
-import go from "highlight.js/lib/languages/go";
-import java from "highlight.js/lib/languages/java";
-import json from "highlight.js/lib/languages/json";
-import bash from "highlight.js/lib/languages/bash";
-import xml from "highlight.js/lib/languages/xml";
-import css from "highlight.js/lib/languages/css";
-import markdown from "highlight.js/lib/languages/markdown";
-import c from "highlight.js/lib/languages/c";
-import cpp from "highlight.js/lib/languages/cpp";
-import csharp from "highlight.js/lib/languages/csharp";
-import php from "highlight.js/lib/languages/php";
-import ruby from "highlight.js/lib/languages/ruby";
-import rust from "highlight.js/lib/languages/rust";
-import yaml from "highlight.js/lib/languages/yaml";
-import sql from "highlight.js/lib/languages/sql";
-import "highlight.js/styles/github.css";
-
-hljs.registerLanguage("diff", diff);
-hljs.registerLanguage("javascript", javascript);
-hljs.registerLanguage("typescript", typescript);
-hljs.registerLanguage("python", python);
-hljs.registerLanguage("go", go);
-hljs.registerLanguage("java", java);
-hljs.registerLanguage("json", json);
-hljs.registerLanguage("bash", bash);
-hljs.registerLanguage("xml", xml);
-hljs.registerLanguage("css", css);
-hljs.registerLanguage("markdown", markdown);
-hljs.registerLanguage("c", c);
-hljs.registerLanguage("cpp", cpp);
-hljs.registerLanguage("csharp", csharp);
-hljs.registerLanguage("php", php);
-hljs.registerLanguage("ruby", ruby);
-hljs.registerLanguage("rust", rust);
-hljs.registerLanguage("yaml", yaml);
-hljs.registerLanguage("sql", sql);
+import { hljs, getLanguageFromPath } from "@/lib/highlight";
 
 interface CommitDetailsDialogProps {
   commitHash: string | null;
@@ -104,44 +64,6 @@ export default function CommitDetailsDialog({
       default:
         return <FileText className="h-3 w-3" />;
     }
-  };
-
-  const extensionToLanguage: Record<string, string> = {
-    js: "javascript",
-    jsx: "javascript",
-    ts: "typescript",
-    tsx: "typescript",
-    py: "python",
-    go: "go",
-    java: "java",
-    rb: "ruby",
-    php: "php",
-    rs: "rust",
-    c: "c",
-    h: "c",
-    cpp: "cpp",
-    cxx: "cpp",
-    hpp: "cpp",
-    cc: "cpp",
-    cs: "csharp",
-    sh: "bash",
-    bash: "bash",
-    zsh: "bash",
-    json: "json",
-    yml: "yaml",
-    yaml: "yaml",
-    toml: "toml",
-    md: "markdown",
-    markdown: "markdown",
-    html: "xml",
-    xml: "xml",
-    css: "css",
-    sql: "sql",
-  };
-
-  const getLanguageFromPath = (path: string): string | undefined => {
-    const ext = path.split(".").pop()?.toLowerCase();
-    return ext ? extensionToLanguage[ext] : undefined;
   };
 
   const renderPatch = (patch: string, language?: string) => {

--- a/www/src/lib/highlight.ts
+++ b/www/src/lib/highlight.ts
@@ -1,0 +1,84 @@
+import hljs from "highlight.js/lib/core";
+import diff from "highlight.js/lib/languages/diff";
+import javascript from "highlight.js/lib/languages/javascript";
+import typescript from "highlight.js/lib/languages/typescript";
+import python from "highlight.js/lib/languages/python";
+import go from "highlight.js/lib/languages/go";
+import java from "highlight.js/lib/languages/java";
+import json from "highlight.js/lib/languages/json";
+import bash from "highlight.js/lib/languages/bash";
+import xml from "highlight.js/lib/languages/xml";
+import css from "highlight.js/lib/languages/css";
+import markdown from "highlight.js/lib/languages/markdown";
+import c from "highlight.js/lib/languages/c";
+import cpp from "highlight.js/lib/languages/cpp";
+import csharp from "highlight.js/lib/languages/csharp";
+import php from "highlight.js/lib/languages/php";
+import ruby from "highlight.js/lib/languages/ruby";
+import rust from "highlight.js/lib/languages/rust";
+import yaml from "highlight.js/lib/languages/yaml";
+import sql from "highlight.js/lib/languages/sql";
+import toml from "highlight.js/lib/languages/toml";
+import "highlight.js/styles/github.css";
+
+hljs.registerLanguage("diff", diff);
+hljs.registerLanguage("javascript", javascript);
+hljs.registerLanguage("typescript", typescript);
+hljs.registerLanguage("python", python);
+hljs.registerLanguage("go", go);
+hljs.registerLanguage("java", java);
+hljs.registerLanguage("json", json);
+hljs.registerLanguage("bash", bash);
+hljs.registerLanguage("xml", xml);
+hljs.registerLanguage("css", css);
+hljs.registerLanguage("markdown", markdown);
+hljs.registerLanguage("c", c);
+hljs.registerLanguage("cpp", cpp);
+hljs.registerLanguage("csharp", csharp);
+hljs.registerLanguage("php", php);
+hljs.registerLanguage("ruby", ruby);
+hljs.registerLanguage("rust", rust);
+hljs.registerLanguage("yaml", yaml);
+hljs.registerLanguage("sql", sql);
+hljs.registerLanguage("toml", toml);
+
+const extensionToLanguage: Record<string, string> = {
+  js: "javascript",
+  jsx: "javascript",
+  ts: "typescript",
+  tsx: "typescript",
+  py: "python",
+  go: "go",
+  java: "java",
+  rb: "ruby",
+  php: "php",
+  rs: "rust",
+  c: "c",
+  h: "c",
+  cpp: "cpp",
+  cxx: "cpp",
+  hpp: "cpp",
+  cc: "cpp",
+  cs: "csharp",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  json: "json",
+  yml: "yaml",
+  yaml: "yaml",
+  toml: "toml",
+  md: "markdown",
+  markdown: "markdown",
+  html: "xml",
+  xml: "xml",
+  css: "css",
+  sql: "sql",
+};
+
+export const getLanguageFromPath = (path: string): string | undefined => {
+  const ext = path.split(".").pop()?.toLowerCase();
+  return ext ? extensionToLanguage[ext] : undefined;
+};
+
+export { hljs };
+


### PR DESCRIPTION
## Summary
- add shared highlight.js setup and language detection utility
- apply syntax highlighting in file viewer and commit details dialog

## Testing
- `npm test`
- `npm run lint` *(fails: Drawer is defined but never used, An interface declaring no members, Unexpected any)*
- `go test ./...` *(fails: Expected status 200, got 500, IsIgnored false expected true)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bd561994832f96d19e5d43f65766