### PR TITLE
Add middleware unit tests

### DIFF
--- a/server/internal/api/middleware/logger_test.go
+++ b/server/internal/api/middleware/logger_test.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLogger(t *testing.T) {
+	var buf bytes.Buffer
+	origWriter := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(origWriter)
+
+	handler := Logger(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	if buf.Len() == 0 {
+		t.Error("Expected log output, got none")
+	}
+}
+
+func TestRecoverer(t *testing.T) {
+	handler := Recoverer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for API middleware logger and panic recoverer

## Testing
- `go test ./server/internal/api/middleware -run Test -count=1`
- `go test ./... 2>&1 | tail -n 20` *(fails: expected status 200, got 500; IsIgnored("node_modules/package.json", false) = false; File should not be staged after unstaging)*


------
https://chatgpt.com/codex/tasks/task_e_68a1bd6c8c00832f91e7b1167ec8bf66